### PR TITLE
Fix running Electron as root

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
     "typecheck": "npm run typecheck:node && npm run typecheck:web",
     "start": "electron-vite preview",
-    "dev": "electron-vite dev",
+    "dev": "electron-vite dev --noSandbox",
     "build": "npm run typecheck && electron-vite build",
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,11 @@
 import { app, shell, BrowserWindow, ipcMain, dialog } from 'electron'
+
+// Running Electron as root without disabling sandbox will cause a crash.
+// Append the `no-sandbox` switch when detected to allow development in
+// containerised environments where the process typically runs as root.
+if (process.getuid && process.getuid() === 0) {
+  app.commandLine.appendSwitch('no-sandbox')
+}
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'


### PR DESCRIPTION
## Summary
- disable sandbox when running as root so app won't crash
- pass `--noSandbox` to electron-vite in development

## Testing
- `pnpm dev` *(fails: Missing X server or $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_687959c72ae083338b2719bb0d6981c8