### PR TITLE
feat(ui): add cyberpunk theme and neon visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An Electron application with React and TypeScript
 
+## Features
+
+- Cyberpunk-inspired theme with neon gradients
+
 ## Recommended IDE Setup
 
 - [VSCode](https://code.visualstudio.com/) + [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) + [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -30,6 +30,7 @@ function App(): React.JSX.Element {
   const drawVisualization = useCallback((): void => {
     const canvas = canvasRef.current
     if (!canvas || !analyserRef.current) return
+
     const ctx = canvas.getContext('2d')!
     const bufferLength = analyserRef.current.frequencyBinCount
     const dataArray = new Uint8Array(bufferLength)
@@ -39,9 +40,13 @@ function App(): React.JSX.Element {
     const barWidth = (canvas.width / bufferLength) * 2.5
     let x = 0
 
+    const gradient = ctx.createLinearGradient(0, canvas.height, 0, 0)
+    gradient.addColorStop(0, '#00ffff')
+    gradient.addColorStop(1, '#ff00ff')
+    ctx.fillStyle = gradient
+
     for (let i = 0; i < bufferLength; i++) {
       const barHeight = dataArray[i]
-      ctx.fillStyle = `rgb(${barHeight + 100}, 50, 50)`
       ctx.fillRect(x, canvas.height - barHeight / 2, barWidth, barHeight / 2)
       x += barWidth + 1
     }
@@ -87,13 +92,13 @@ function App(): React.JSX.Element {
   }
 
   const Visualizer = (): React.JSX.Element => (
-    <div className="w-full h-full bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg flex items-center justify-center">
+    <div className="w-full h-full bg-gradient-to-br from-cyan-500 to-fuchsia-600 rounded-lg flex items-center justify-center">
       <canvas ref={canvasRef} className="w-full h-full" />
     </div>
   )
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div data-theme="cyberpunk" className="min-h-screen bg-background flex flex-col">
       <PanelGroup direction="horizontal" className="flex-1">
         <Panel defaultSize={20} minSize={15} className="bg-secondary p-4">
           <h2 className="text-lg font-bold mb-2">Tracks</h2>

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -74,6 +74,43 @@
   --chart-5: 340 75% 55%;
 }
 
+@theme [data-theme="cyberpunk"] {
+  /* Neon-inspired palette for a cyberpunk aesthetic */
+  --background: 261 56% 6%;
+  --foreground: 180 100% 97%;
+
+  --card: 261 56% 10%;
+  --card-foreground: 180 100% 97%;
+
+  --popover: 261 56% 8%;
+  --popover-foreground: 180 100% 97%;
+
+  --primary: 312 100% 50%;
+  --primary-foreground: 0 0% 0%;
+
+  --secondary: 180 100% 50%;
+  --secondary-foreground: 0 0% 0%;
+
+  --muted: 261 56% 20%;
+  --muted-foreground: 180 25% 85%;
+
+  --accent: 312 100% 50%;
+  --accent-foreground: 0 0% 0%;
+
+  --destructive: 0 100% 50%;
+  --destructive-foreground: 0 0% 0%;
+
+  --border: 261 56% 20%;
+  --input: 261 56% 20%;
+  --ring: 312 100% 50%;
+
+  --chart-1: 312 100% 50%;
+  --chart-2: 180 100% 50%;
+  --chart-3: 51 100% 50%;
+  --chart-4: 39 100% 50%;
+  --chart-5: 266 100% 60%;
+}
+
 body {
   background-color: hsl(var(--background));
   color: hsl(var(--foreground));


### PR DESCRIPTION
## Summary
- add cyberpunk design tokens and default theme
- render neon gradient bars for audio visualization
- document the new theme in README

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68958082cb548333bd59946253590270