### PR TITLE
feat: render audio visualizer with dynamic rainbow bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ An Electron application with React and TypeScript
 ## Features
 
 - Cyberpunk-inspired theme with neon gradients
+- Rainbow frequency-bar visualizer that reacts to your audio
 
 ## Recommended IDE Setup
 


### PR DESCRIPTION
## Summary
- add rainbow audio spectrum bars and smoothed animation
- mention visualizer feature in README

## Testing
- `pnpm lint`
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68959fe4e9b48333a72f0543efcc062a